### PR TITLE
updated documentation: py2puml requires python 3.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Generate PlantUML class diagrams to document your Python application.
 `py2puml` produces a class diagram [PlantUML script](https://plantuml.com/en/class-diagram) representing classes properties (static and instance attributes) and their relations (composition and inheritance relationships).
 
 `py2puml` internally uses code [inspection](https://docs.python.org/3/library/inspect.html) (also called *reflexion* in other programming languages) and [abstract tree parsing](https://docs.python.org/3/library/ast.html) to retrieve relevant information.
+Some parsing features are available only since Python 3.8 (like [ast.get_source_segment](https://docs.python.org/3/library/ast.html#ast.get_source_segment)).
 
 ## Features
 
@@ -179,6 +180,7 @@ poetry run python -m pytest -v --cov=py2puml --cov-branch --cov-report term-miss
 
 # Changelog
 
+* `0.5.2`: specify in pyproject.toml that py2puml requires python 3.8+ (`ast.get_source_segment` was introduced in 3.8)
 * `0.5.1`: prevent from parsing inherited constructors
 * `0.5.0`: handle instance attributes in class constructors, add code coverage of unit tests
 * `0.4.0`: add a simple CLI

--- a/py2puml/cli.py
+++ b/py2puml/cli.py
@@ -9,7 +9,7 @@ from py2puml.py2puml import py2puml
 def run():
     argparser = ArgumentParser(description='Generate PlantUML class diagrams to document your Python application.')
 
-    argparser.add_argument('-v', '--version', action='version', version='py2puml 0.5.1')
+    argparser.add_argument('-v', '--version', action='version', version='py2puml 0.5.2')
     argparser.add_argument('path', metavar='path', type=str, help='the path of the domain')
     argparser.add_argument('module', metavar='module', type=str, help='the module of the domain', default=None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py2puml"
-version = "0.5.1"
+version = "0.5.2"
 description = "Generate PlantUML class diagrams to document your Python application."
 keywords = ["class diagram", "PlantUML", "documentation", "inspection", "AST"]
 readme = "README.md"
@@ -13,7 +13,7 @@ license = "MIT"
 py2puml = 'py2puml.cli:run'
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.2"

--- a/tests/py2puml/test__init__.py
+++ b/tests/py2puml/test__init__.py
@@ -2,7 +2,7 @@ from tests import __version__, __description__
 
 # Ensures the library version is modified in the pyproject.toml file when upgrading it (pull request)
 def test_version():
-    assert __version__ == '0.5.1'
+    assert __version__ == '0.5.2'
 
 # Description also output in the CLI
 def test_description():


### PR DESCRIPTION
closes #17 