### PR TITLE
fix(compoundtypesplitter): handle class names with digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ poetry run python -m pytest -v --cov=py2puml --cov-branch --cov-report term-miss
 
 # Changelog
 
-* `0.6.0`: handle abstract classes
+* `0.6.1`: handle class names with digits
+* `0.6.1`: handle abstract classes
 * `0.5.4`: fixed the packaging so that the contribution guide is included in the published package
 * `0.5.3`: handle constructors decorated by wrapping decorators (decorators making uses of `functools.wrap`)
 * `0.5.2`: specify in pyproject.toml that py2puml requires python 3.8+ (`ast.get_source_segment` was introduced in 3.8)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ poetry run python -m pytest -v --cov=py2puml --cov-branch --cov-report term-miss
 # Changelog
 
 * `0.6.1`: handle class names with digits
-* `0.6.1`: handle abstract classes
+* `0.6.0`: handle abstract classes
 * `0.5.4`: fixed the packaging so that the contribution guide is included in the published package
 * `0.5.3`: handle constructors decorated by wrapping decorators (decorators making uses of `functools.wrap`)
 * `0.5.2`: specify in pyproject.toml that py2puml requires python 3.8+ (`ast.get_source_segment` was introduced in 3.8)

--- a/py2puml/cli.py
+++ b/py2puml/cli.py
@@ -9,7 +9,7 @@ from py2puml.py2puml import py2puml
 def run():
     argparser = ArgumentParser(description='Generate PlantUML class diagrams to document your Python application.')
 
-    argparser.add_argument('-v', '--version', action='version', version='py2puml 0.6.0')
+    argparser.add_argument('-v', '--version', action='version', version='py2puml 0.6.1')
     argparser.add_argument('path', metavar='path', type=str, help='the path of the domain')
     argparser.add_argument('module', metavar='module', type=str, help='the module of the domain', default=None)
 

--- a/py2puml/parsing/compoundtypesplitter.py
+++ b/py2puml/parsing/compoundtypesplitter.py
@@ -2,7 +2,7 @@
 from re import compile, Pattern
 from typing import List, Tuple
 
-IS_COMPOUND_TYPE: Pattern = compile('^[a-z|A-Z|\\[|\\]|\\.|,|\\s|_]+$')
+IS_COMPOUND_TYPE: Pattern = compile('^[a-z|A-Z|0-9|\\[|\\]|\\.|,|\\s|_]+$')
 SPLITTING_CHARACTERS = ('[', ']', ',')
 
 class CompoundTypeSplitter(object):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py2puml"
-version = "0.6.0"
+version = "0.6.1"
 description = "Generate PlantUML class diagrams to document your Python application."
 keywords = ["class diagram", "PlantUML", "documentation", "inspection", "AST"]
 readme = "README.md"

--- a/tests/modules/withcompoundtypewithdigits.py
+++ b/tests/modules/withcompoundtypewithdigits.py
@@ -1,0 +1,12 @@
+from typing import List
+
+
+class IPv6:
+    '''class name with digits'''
+    def __init__(self, address: str) -> None:
+        self.address: str = address
+
+class Multicast:
+    def __init__(self, address: IPv6, repetition: int):
+        # List[IPv6] must be parsed
+        self.addresses: List[IPv6] = [address] * repetition

--- a/tests/py2puml/parsing/test_compoundtypesplitter.py
+++ b/tests/py2puml/parsing/test_compoundtypesplitter.py
@@ -34,6 +34,7 @@ def test_CompoundTypeSplitter_from_invalid_types(type_annotation: str):
     ('_ast.Name', ('_ast.Name',)),
     ('Tuple[str, withenum.TimeUnit]', ('Tuple', '[', 'str', ',', 'withenum.TimeUnit', ']')),
     ('List[datetime.date]', ('List', '[', 'datetime.date', ']')),
+    ('List[IPv6]', ('List', '[', 'IPv6', ']')),
     ('modules.withenum.TimeUnit', ('modules.withenum.TimeUnit',)),
     ('Dict[str, Dict[str,builtins.float]]', ('Dict', '[', 'str', ',', 'Dict', '[', 'str', ',', 'builtins.float', ']', ']')),
 ])

--- a/tests/py2puml/test__init__.py
+++ b/tests/py2puml/test__init__.py
@@ -2,7 +2,7 @@ from tests import __version__, __description__
 
 # Ensures the library version is modified in the pyproject.toml file when upgrading it (pull request)
 def test_version():
-    assert __version__ == '0.6.0'
+    assert __version__ == '0.6.1'
 
 # Description also output in the CLI
 def test_description():


### PR DESCRIPTION
py2puml should handle class names that include digits, like:

```python
class int64:
    def __init__(self, value: int) -> None:
        self.value: int = value

class Main:
    def __init__(self):
        self.a: list[int64] = [int64(0)] * 5
```

