### PR TITLE
fix crash trying to extend None list member

### DIFF
--- a/py2puml/parsing/astvisitors.py
+++ b/py2puml/parsing/astvisitors.py
@@ -85,9 +85,9 @@ class ConstructorVisitor(NodeVisitor):
         self.uml_relations_by_target_fqn.update({
             target_fqn: UmlRelation(self.class_fqn, target_fqn, RelType.COMPOSITION)
             for target_fqn in target_fqns
-            if target_fqn.startswith(self.root_fqn) and (
-                target_fqn not in self.uml_relations_by_target_fqn
-            )
+            if target_fqn
+            and target_fqn.startswith(self.root_fqn)
+            and (target_fqn not in self.uml_relations_by_target_fqn)
         })
 
     def get_from_namespace(self, variable_id: str) -> Variable:


### PR DESCRIPTION
attempting `py2puml elfpy elfpy > elfpy.plantuml` on [https://github.com/element-fi/elf-simulations/tree/2349ebf365f5c3c589ad42d85a263a241010dac7](https://github.com/element-fi/elf-simulations/tree/2349ebf365f5c3c589ad42d85a263a241010dac7)
```
Traceback (most recent call last):
  File "/Users/mihai/.pyenv/versions/py2puml/bin/py2puml", line 8, in <module>
    sys.exit(run())
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/cli.py", line 24, in run
    print(''.join(py2puml(args.path, args.module)))
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/py2puml.py", line 12, in py2puml
    inspect_package(
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/inspection/inspectpackage.py", line 20, in inspect_package
    inspect_module(
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/inspection/inspectmodule.py", line 60, in inspect_module
    inspect_domain_definition(definition_type, root_module_name, domain_items_by_fqn, domain_relations)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/inspection/inspectmodule.py", line 47, in inspect_domain_definition
    inspect_class_type(
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/inspection/inspectclass.py", line 103, in inspect_class_type
    instance_attributes, compositions = parse_class_constructor(class_type, class_type_fqn, root_module_name)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/parseclassconstructor.py", line 42, in parse_class_constructor
    visitor.visit(constructor_ast)
  File "/Users/mihai/.pyenv/versions/3.10.10/lib/python3.10/ast.py", line 418, in visit
    return visitor(node)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 103, in generic_visit
    NodeVisitor.generic_visit(self, node)
  File "/Users/mihai/.pyenv/versions/3.10.10/lib/python3.10/ast.py", line 426, in generic_visit
    self.visit(item)
  File "/Users/mihai/.pyenv/versions/3.10.10/lib/python3.10/ast.py", line 418, in visit
    return visitor(node)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 113, in visit_FunctionDef
    self.generic_visit(node)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 103, in generic_visit
    NodeVisitor.generic_visit(self, node)
  File "/Users/mihai/.pyenv/versions/3.10.10/lib/python3.10/ast.py", line 426, in generic_visit
    self.visit(item)
  File "/Users/mihai/.pyenv/versions/3.10.10/lib/python3.10/ast.py", line 418, in visit
    return visitor(node)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 150, in visit_Assign
    self.extend_relations(full_namespaced_definitions)
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 85, in extend_relations
    self.uml_relations_by_target_fqn.update({
  File "/Users/mihai/.pyenv/versions/3.10.10/envs/py2puml/lib/python3.10/site-packages/py2puml/parsing/astvisitors.py", line 88, in <dictcomp>
    if target_fqn.startswith(self.root_fqn) and (
AttributeError: 'NoneType' object has no attribute 'startswith'
```