### PR TITLE
Update proposal for annotated types - also enables pydantic annotated types

### DIFF
--- a/py2puml/parsing/compoundtypesplitter.py
+++ b/py2puml/parsing/compoundtypesplitter.py
@@ -1,5 +1,7 @@
 from re import Pattern
 from re import compile as re_compile
+from re import sub as re_sub
+
 from typing import Tuple
 
 # a class name wrapped by ForwardRef(...)
@@ -13,6 +15,33 @@ SPLITTING_CHARACTERS = '[', ']', ',', '|'
 
 # 'None' in 'Union[str, None]' type signature is changed into 'NoneType' when inspecting a module
 LAST_NONETYPE_IN_UNION: Pattern = re_compile(r'Union\[(?:(?:[^\[\]])*NoneType)')
+
+def replace_typing_annotated_with_type(compound_type_annotation: str) -> str:
+    """Replace all occurances of typing.Annotated[type, extraInfo] with type.
+    
+    This simplifies the compound_type_annotation for further processing, losing the extraInfo.
+    
+    Even nested replacements are possible, e.g. 
+    typing.Annotated[typing.Annotated[type, extraInfo], extraInfo] is replaced by type.
+    
+    Since the extraInfo can be a complex string with alot of () and [] when Field from pydantic is used,
+    the "problematic" strings from the extraInfo are detected and removed first to be able to remove the
+    whole extraInfo part robustly.
+    """
+    simple_compound_type_annotation = compound_type_annotation
+    
+    # Remove metadata[....] from extraInfo if present
+    simple_compound_type_annotation = re_sub(r"metadata=\[(.*?)\]", "", simple_compound_type_annotation)
+    
+    # Then remove the FieldInfo(...) if present
+    simple_compound_type_annotation = re_sub(r"FieldInfo\((.*?)\)", "", simple_compound_type_annotation)
+    
+    # Remove the typing.Annotated (recursively if they are nested)
+    re_search_rule = r'typing\.Annotated\[(.*?)\,(.*?)]'
+    while('typing.Annotated' in simple_compound_type_annotation):
+        simple_compound_type_annotation = re_sub(re_search_rule, r'\1', simple_compound_type_annotation)
+        
+    return simple_compound_type_annotation
 
 
 def remove_forward_references(compound_type_annotation: str, module_name: str) -> str:
@@ -52,8 +81,11 @@ class CompoundTypeSplitter:
     Splits the representation of a compound type annotation into a list of:
     - its components (that can be resolved against the module where the type annotation was found)
     - its structuring characters: '[', ']' and ','
+    
+    Also removes the typing.Annotated[type, extraInfo] string to directly get the acutal type.
     '''
     def __init__(self, compound_type_annotation: str, module_name: str):
+        compound_type_annotation = replace_typing_annotated_with_type(compound_type_annotation)
         resolved_type_annotations = remove_forward_references(compound_type_annotation, module_name)
         resolved_type_annotations = replace_nonetype_occurrences_in_union_types(resolved_type_annotations)
         if (resolved_type_annotations is None) or not IS_COMPOUND_TYPE.match(resolved_type_annotations):


### PR DESCRIPTION
This would solve goal 1 of Issue 65.

https://github.com/lucsorel/py2puml/issues/65

-> Annotated types are useful in combination with pydantic to validate dataclasses (e.g. ranges of int)
-> This PR makes it work with annotated types, but I think it feels quite "hard coded".
-> I tested it locally with different pydantic types and custom created types via typing_extensions.Annotated
-> Please feel free to use this PR as idea input and implement this functionality where it fits best in the code base.