### PR TITLE
Expose controls on which block, method, relation can be included in uml diagram

### DIFF
--- a/py2puml/py2puml.py
+++ b/py2puml/py2puml.py
@@ -6,9 +6,9 @@ from py2puml.export.puml import to_puml_content
 from py2puml.inspection.inspectpackage import inspect_package
 
 
-def py2puml(domain_path: str, domain_module: str) -> Iterable[str]:
+def py2puml(domain_path: str, domain_module: str, **kwargs) -> Iterable[str]:
     domain_items_by_fqn: Dict[str, UmlItem] = {}
     domain_relations: List[UmlRelation] = []
     inspect_package(domain_path, domain_module, domain_items_by_fqn, domain_relations)
 
-    return to_puml_content(domain_module, domain_items_by_fqn.values(), domain_relations)
+    return to_puml_content(domain_module, domain_items_by_fqn.values(), domain_relations, **kwargs)


### PR DESCRIPTION
For my usecase, I need to ignore some portions in the uml diagram whenever i was generating, thought it would be useful for others as well, so raising this PR

If you are planning to merge this, close the PR #43 before this one, as i also exposed controls for methods
Usage
```python
from py2puml.domain.umlclass import UmlMethod
from py2puml.domain.umlitem import UmlItem
from py2puml.domain.umlrelation import UmlRelation
from py2puml.py2puml import py2puml

def is_method_valid(uml_method: UmlMethod) -> bool:
    """Check if a method can be included in the UML diagram."""
    return uml_method.name != "__init__"


def is_block_valid(uml_item: UmlItem) -> bool:
    """Check if a block can be included in diagram."""
    return not uml_item.fqn.startswith("app.utils")


def is_relation_valid(uml_relation: UmlRelation) -> bool:
    """Check if a relation can be made in diagram."""
    return not (
        uml_relation.source_fqn.startswith("app.utils")
        or uml_relation.target_fqn.startswith("app.utils")
    )

puml_content = "".join(
        py2puml(
            APP_PATH,
            MODULE,
            is_method_valid=is_method_valid,
            is_block_valid=is_block_valid,
            is_relation_valid=is_relation_valid,
        )
    )
```